### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ keywords = [
 async-trait = "^0.1.52"
 oauth10a = "^1.3.0"
 log = { version = "^0.4.14", optional = true }
-hyper = { version = "^0.14.16", default-features = false }
+hyper = { version = "^0.14.17", default-features = false }
 schemars = { version = "^0.8.8", features = [
     "chrono",
     "indexmap",
@@ -33,7 +33,7 @@ schemars = { version = "^0.8.8", features = [
 serde = { version = "^1.0.136", features = ["derive"] }
 serde_repr = "^0.1.7"
 thiserror = "^1.0.30"
-tracing = { version = "^0.1.29", optional = true }
+tracing = { version = "^0.1.30", optional = true }
 tracing-futures = { version = "^0.2.5", optional = true }
 uuid = { version = "^0.8.2", features = ["serde", "v4"] }
 


### PR DESCRIPTION
* Bump hyper to 0.14.17
* Bump tracing to 0.1.30

Signed-off-by: Florentin Dubois <florentin.dubois@clever-cloud.com>