### PR TITLE
Update oauth10a dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ keywords = [
 
 [dependencies]
 async-trait = "^0.1.52"
-oauth10a = "^1.3.1"
+oauth10a = "^1.3.2"
 log = { version = "^0.4.14", optional = true }
 hyper = { version = "^0.14.17", default-features = false }
 schemars = { version = "^0.8.8", features = [


### PR DESCRIPTION
* Bump oauth10a to 1.3.2

Signed-off-by: Florentin Dubois <florentin.dubois@clever-cloud.com>