### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,10 +19,10 @@ keywords = [
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-async-trait = "^0.1.52"
-oauth10a = "^1.3.2"
+async-trait = "^0.1.53"
+oauth10a = "^1.3.3"
 log = { version = "^0.4.14", optional = true }
-hyper = { version = "^0.14.17", default-features = false }
+hyper = { version = "^0.14.18", default-features = false }
 schemars = { version = "^0.8.8", features = [
     "chrono",
     "indexmap",


### PR DESCRIPTION
* Bump async-trait to 0.1.53
* Bump oauth10a to 1.3.3
* Bump hyper to 0.14.18

Signed-off-by: Florentin Dubois <florentin.dubois@clever-cloud.com>