### PR TITLE
Update cleverctl example dependencies

### DIFF
--- a/examples/cleverctl/Cargo.toml
+++ b/examples/cleverctl/Cargo.toml
@@ -9,15 +9,15 @@ edition = "2021"
 [dependencies]
 async-trait = "^0.1.53"
 clevercloud-sdk = { path = "../..", features = ["tokio", "metrics", "trace", "jsonschemas"] }
-config = "^0.13.0"
+clap = { version = "^3.1.18", features = ["derive"] }
+config = "^0.13.1"
 paw = "^1.0.0"
-serde = { version = "^1.0.136", features = ["derive"] }
-serde_json = "^1.0.79"
-serde_yaml = "^0.8.23"
+serde = { version = "^1.0.137", features = ["derive"] }
+serde_json = "^1.0.81"
+serde_yaml = "^0.8.24"
 slog = "^2.7.0"
 slog-async = "^2.7.0"
 slog-term = "^2.9.0"
 slog-scope = "^4.4.0"
-structopt = { version = "^0.3.26", features = ["paw"] }
-thiserror = "^1.0.30"
-tokio = { version = "^1.17.0", features = ["full"] }
+thiserror = "^1.0.31"
+tokio = { version = "^1.18.2", features = ["full"] }

--- a/examples/cleverctl/src/cmd/addon/config_provider/environment.rs
+++ b/examples/cleverctl/src/cmd/addon/config_provider/environment.rs
@@ -8,7 +8,7 @@ use clevercloud_sdk::{
     v4::addon_provider::config_provider::addon::environment::{self, Variable},
     Client,
 };
-use structopt::StructOpt;
+use clap::Subcommand;
 use tokio::{fs, task::spawn_blocking as blocking};
 
 use crate::{
@@ -40,58 +40,58 @@ pub enum Error {
 // -----------------------------------------------------------------------------
 // Environment enumeration
 
-#[derive(StructOpt, PartialEq, Eq, Clone, Debug)]
+#[derive(Subcommand, PartialEq, Eq, Clone, Debug)]
 pub enum Environment {
     /// Get environment variables
-    #[structopt(name = "get")]
+    #[clap(name = "get")]
     Get {
         /// Specify the output format
-        #[structopt(short = "o", long = "output", default_value)]
+        #[clap(short = 'o', long = "output", default_value_t)]
         output: Output,
         /// Specify the config-provider identifier
-        #[structopt(name = "config-provider-identifier")]
+        #[clap(name = "config-provider-identifier")]
         id: String,
     },
     /// Insert an environment variable
-    #[structopt(name = "insert", aliases = &["i"])]
+    #[clap(name = "insert", aliases = &["i"])]
     Insert {
         /// Specify the output format
-        #[structopt(short = "o", long = "output", default_value)]
+        #[clap(short = 'o', long = "output", default_value_t)]
         output: Output,
         /// Specify the config-provider identifier
-        #[structopt(name = "config-provider-identifier")]
+        #[clap(name = "config-provider-identifier")]
         id: String,
         /// Specify the name of the environment variable to insert
-        #[structopt(name = "name")]
+        #[clap(name = "name")]
         name: String,
         /// Specify the value of the environment variable to insert
-        #[structopt(name = "value")]
+        #[clap(name = "value")]
         value: String,
     },
     /// Update environment variables
-    #[structopt(name = "put")]
+    #[clap(name = "put")]
     Put {
         /// Specify the output format
-        #[structopt(short = "o", long = "output", default_value)]
+        #[clap(short = 'o', long = "output", default_value_t)]
         output: Output,
         /// Specify the config-provider identifier
-        #[structopt(name = "config-provider-identifier")]
+        #[clap(name = "config-provider-identifier")]
         id: String,
         /// Specify the json file to read
-        #[structopt(name = "file")]
+        #[clap(name = "file")]
         file: PathBuf,
     },
     /// Remove an environment variable
-    #[structopt(name = "remove", aliases = &["r"])]
+    #[clap(name = "remove", aliases = &["r"])]
     Remove {
         /// Specify the output format
-        #[structopt(short = "o", long = "output", default_value)]
+        #[clap(short = 'o', long = "output", default_value_t)]
         output: Output,
         /// Specify the config-provider identifier
-        #[structopt(name = "config-provider-identifier")]
+        #[clap(name = "config-provider-identifier")]
         id: String,
         /// Specify the name of the environment variable to remove
-        #[structopt(name = "name")]
+        #[clap(name = "name")]
         name: String,
     },
 }

--- a/examples/cleverctl/src/cmd/addon/config_provider/mod.rs
+++ b/examples/cleverctl/src/cmd/addon/config_provider/mod.rs
@@ -4,7 +4,7 @@
 
 use std::sync::Arc;
 
-use structopt::StructOpt;
+use clap::Subcommand;
 
 use crate::{
     cfg::Configuration,
@@ -25,10 +25,10 @@ pub enum Error {
 // -----------------------------------------------------------------------------
 // ConfigProvider structure
 
-#[derive(StructOpt, Eq, PartialEq, Clone, Debug)]
+#[derive(Subcommand, Eq, PartialEq, Clone, Debug)]
 pub enum ConfigProvider {
     /// Interact with config-provider environment
-    #[structopt(name = "environment", aliases = &["env"])]
+    #[clap(name = "environment", aliases = &["env"], subcommand)]
     Environment(Environment),
 }
 

--- a/examples/cleverctl/src/cmd/addon/mod.rs
+++ b/examples/cleverctl/src/cmd/addon/mod.rs
@@ -3,6 +3,7 @@
 //! This module provides command implementation related to addons
 use std::sync::Arc;
 
+use clap::Subcommand;
 use clevercloud_sdk::{
     oauth10a::{
         proxy::{self, ProxyConnectorBuilder},
@@ -11,7 +12,6 @@ use clevercloud_sdk::{
     v2::addon,
     Client,
 };
-use structopt::StructOpt;
 
 use crate::{
     cfg::Configuration,
@@ -40,33 +40,33 @@ pub enum Error {
 // -----------------------------------------------------------------------------
 // Addon enumeration
 
-#[derive(StructOpt, Eq, PartialEq, Clone, Debug)]
+#[derive(Subcommand, Eq, PartialEq, Clone, Debug)]
 pub enum Command {
     /// List addons of an organisation
-    #[structopt(name = "list")]
+    #[clap(name = "list")]
     List {
         /// Specify the output format
-        #[structopt(short = "o", long = "output", default_value)]
+        #[clap(short = 'o', long = "output", default_value_t)]
         output: Output,
         /// Specify the organisation identifier
-        #[structopt(name = "organisation-identifier")]
+        #[clap(name = "organisation-identifier")]
         organisation_id: String,
     },
     /// Get addon of an organisation
-    #[structopt(name = "get")]
+    #[clap(name = "get")]
     Get {
         /// Specify the output format
-        #[structopt(short = "o", long = "output", default_value)]
+        #[clap(short = 'o', long = "output", default_value_t)]
         output: Output,
         /// Specify the organisation identifier
-        #[structopt(name = "organisation-identifier")]
+        #[clap(name = "organisation-identifier")]
         organisation_id: String,
         /// Specify the addon identifier
-        #[structopt(name = "addon-identifier")]
+        #[clap(name = "addon-identifier")]
         addon_id: String,
     },
     /// Interact with ConfigProvider addon
-    #[structopt(name = "config-provider", aliases = &["cp"])]
+    #[clap(name = "config-provider", aliases = &["cp"], subcommand)]
     ConfigProvider(ConfigProvider),
 }
 

--- a/examples/cleverctl/src/cmd/mod.rs
+++ b/examples/cleverctl/src/cmd/mod.rs
@@ -9,8 +9,9 @@ use std::{
     sync::Arc,
 };
 
+use clap::{Parser, Subcommand};
 use serde::Serialize;
-use structopt::StructOpt;
+use paw::ParseArgs;
 
 use crate::cfg::Configuration;
 
@@ -100,16 +101,16 @@ pub trait Executor {
 // Command enumeration
 
 /// Command enum contains all operations that the command line could handle
-#[derive(StructOpt, Eq, PartialEq, Clone, Debug)]
+#[derive(Subcommand, Eq, PartialEq, Clone, Debug)]
 pub enum Command {
     /// Interact with the current user
-    #[structopt(name = "self", aliases = &["sel", "se", "s"])]
+    #[clap(name = "self", aliases = &["sel", "se", "s"], subcommand)]
     Myself(myself::Command),
     /// Interact with addons
-    #[structopt(name = "addon", aliases = &["addo", "add", "ad", "a"])]
+    #[clap(name = "addon", aliases = &["addo", "add", "ad", "a"], subcommand)]
     Addon(addon::Command),
     /// Interact with zones
-    #[structopt(name = "zone", aliases = &["zon", "zo", "z"])]
+    #[clap(name = "zone", aliases = &["zon", "zo", "z"], subcommand)]
     Zone(zone::Command),
 }
 
@@ -131,17 +132,26 @@ impl Executor for Command {
 
 /// Args structure contains all commands and global flags that the command line
 /// supports
-#[derive(StructOpt, Eq, PartialEq, Clone, Debug)]
+#[derive(Parser, Eq, PartialEq, Clone, Debug)]
+#[clap(author, version, about)]
 pub struct Args {
     /// Specify a configuration file
-    #[structopt(short = "c", long = "config", global = true)]
+    #[clap(short = 'c', long = "config", global = true)]
     pub config: Option<PathBuf>,
     /// Increase log verbosity
-    #[structopt(short = "v", global = true, parse(from_occurrences))]
+    #[clap(short = 'v', global = true, parse(from_occurrences))]
     pub verbosity: usize,
     /// Check the healthiness of the configuration
-    #[structopt(short = "t", long = "check", global = true)]
+    #[clap(short = 't', long = "check", global = true)]
     pub check: bool,
-    #[structopt(subcommand)]
+    #[clap(subcommand)]
     pub cmd: Command,
+}
+
+impl ParseArgs for Args {
+    type Error = Error;
+
+    fn parse_args() -> Result<Self, Self::Error> {
+        Ok(Args::parse())
+    }
 }

--- a/examples/cleverctl/src/cmd/myself.rs
+++ b/examples/cleverctl/src/cmd/myself.rs
@@ -3,6 +3,7 @@
 //! This module provides command implementation related to the current user
 use std::sync::Arc;
 
+use clap::Subcommand;
 use clevercloud_sdk::{
     oauth10a::{
         proxy::{self, ProxyConnectorBuilder},
@@ -11,7 +12,6 @@ use clevercloud_sdk::{
     v2::myself,
     Client,
 };
-use structopt::StructOpt;
 
 use crate::{
     cfg::Configuration,
@@ -35,13 +35,13 @@ pub enum Error {
 // Command enumeration
 
 /// Command enum contains all operations that could be achieved on the user
-#[derive(StructOpt, Eq, PartialEq, Clone, Debug)]
+#[derive(Subcommand, Eq, PartialEq, Clone, Debug)]
 pub enum Command {
     /// Get information about the current user
-    #[structopt(name = "get", aliases = &["ge", "g"])]
+    #[clap(name = "get", aliases = &["ge", "g"])]
     Get {
         /// Specify the output format
-        #[structopt(short = "o", long = "output", default_value)]
+        #[clap(short = 'o', long = "output", default_value_t)]
         output: Output,
     },
 }

--- a/examples/cleverctl/src/cmd/zone.rs
+++ b/examples/cleverctl/src/cmd/zone.rs
@@ -3,6 +3,7 @@
 //! This module provides command implementation related to the zone API
 use std::sync::Arc;
 
+use clap::Subcommand;
 use clevercloud_sdk::{
     oauth10a::{
         proxy::{self, ProxyConnectorBuilder},
@@ -11,7 +12,6 @@ use clevercloud_sdk::{
     v4::products::zones,
     Client,
 };
-use structopt::StructOpt;
 
 use crate::{
     cfg::Configuration,
@@ -35,27 +35,27 @@ pub enum Error {
 // Command enumeration
 
 /// Command enum contains all operations that could be achieved on the zone API
-#[derive(StructOpt, Eq, PartialEq, Clone, Debug)]
+#[derive(Subcommand, Eq, PartialEq, Clone, Debug)]
 pub enum Command {
     /// List available zones
-    #[structopt(name = "list", aliases = &["l"])]
+    #[clap(name = "list", aliases = &["l"])]
     List {
         /// Specify the output format
-        #[structopt(short = "o", long = "output", default_value)]
+        #[clap(short = 'o', long = "output", default_value_t)]
         output: Output,
     },
     /// List application available zones
-    #[structopt(name = "application", aliases = &["app", "a"])]
+    #[clap(name = "application", aliases = &["app", "a"])]
     Application {
         /// Specify the output format
-        #[structopt(short = "o", long = "output", default_value)]
+        #[clap(short = 'o', long = "output", default_value_t)]
         output: Output,
     },
     /// List hds available zones
-    #[structopt(name = "hds", aliases = &["h"])]
+    #[clap(name = "hds", aliases = &["h"])]
     Hds {
         /// Specify the output format
-        #[structopt(short = "o", long = "output", default_value)]
+        #[clap(short = 'o', long = "output", default_value_t)]
         output: Output,
     },
 }

--- a/examples/cleverctl/src/main.rs
+++ b/examples/cleverctl/src/main.rs
@@ -51,6 +51,12 @@ impl From<std::io::Error> for Error {
     }
 }
 
+impl From<cmd::Error> for Error {
+    fn from(err: cmd::Error) -> Self {
+        Self::Command(err)
+    }
+}
+
 // -----------------------------------------------------------------------------
 // main
 


### PR DESCRIPTION
* Add clap to 3.1.18
* Bump config to 0.13.1
* Bump serde to 1.0.137
* Bump serde_json to 1.0.81
* Bump serde_yaml to 0.8.24
* Remove structopt in favor of clap
* Bump thiserror to 1.0.31
* Bump tokio to 1.18.2

Signed-off-by: Florentin Dubois <florentin.dubois@clever-cloud.com>