### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,9 +20,9 @@ keywords = [
 
 [dependencies]
 async-trait = "^0.1.53"
-oauth10a = "^1.3.7"
+oauth10a = "^1.3.8"
 log = { version = "^0.4.17", optional = true }
-hyper = { version = "^0.14.18", default-features = false }
+hyper = { version = "^0.14.19", default-features = false }
 schemars = { version = "^0.8.10", features = [
     "chrono",
     "indexmap1",
@@ -35,7 +35,7 @@ serde_repr = "^0.1.8"
 thiserror = "^1.0.31"
 tracing = { version = "^0.1.34", optional = true }
 tracing-futures = { version = "^0.2.5", optional = true }
-uuid = { version = "^1.1.0", features = ["serde", "v4"] }
+uuid = { version = "^1.1.1", features = ["serde", "v4"] }
 
 [features]
 default = ["logging"]


### PR DESCRIPTION
* Bump oauth10a to 1.3.8
* Bump hyper to 0.14.19
* Bump uuid to 1.1.1

Signed-off-by: Florentin Dubois <florentin.dubois@clever-cloud.com>