### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,9 +20,9 @@ keywords = [
 
 [dependencies]
 async-trait = "^0.1.56"
-oauth10a = "^1.3.10"
+oauth10a = "^1.3.11"
 log = { version = "^0.4.17", optional = true }
-hyper = { version = "^0.14.19", default-features = false }
+hyper = { version = "^0.14.20", default-features = false }
 schemars = { version = "^0.8.10", features = [
     "chrono",
     "indexmap1",
@@ -30,7 +30,7 @@ schemars = { version = "^0.8.10", features = [
     "bytes",
     "url",
 ], optional = true }
-serde = { version = "^1.0.137", features = ["derive"] }
+serde = { version = "^1.0.139", features = ["derive"] }
 serde_repr = "^0.1.8"
 thiserror = "^1.0.31"
 tracing = { version = "^0.1.35", optional = true }


### PR DESCRIPTION
* Bump oauth10a to 1.3.11
* Bump hyper to 0.14.20
* Bump serde to 1.0.139

Signed-off-by: Florentin Dubois <florentin.dubois@clever-cloud.com>