### PR TITLE
Update cleverctl example's dependencies

### DIFF
--- a/examples/cleverctl/Cargo.toml
+++ b/examples/cleverctl/Cargo.toml
@@ -9,16 +9,16 @@ edition = "2021"
 [dependencies]
 async-trait = "^0.1.56"
 clevercloud-sdk = { path = "../..", features = ["tokio", "metrics", "trace", "jsonschemas"] }
-clap = { version = "^3.2.8", features = ["derive"] }
+clap = { version = "^3.2.12", features = ["derive"] }
 config = "^0.13.1"
 paw = "^1.0.0"
-serde = { version = "^1.0.137", features = ["derive"] }
+serde = { version = "^1.0.139", features = ["derive"] }
 serde_json = "^1.0.82"
-serde_yaml = "^0.8.24"
+serde_yaml = "^0.8.26"
 thiserror = "^1.0.31"
+tokio = { version = "^1.20.0", features = ["full"] }
 tracing = "^0.1.35"
-tracing-subscriber = { version = "^0.3.11", default-features = false, features = ["std", "ansi", "tracing-log"] }
-tokio = { version = "^1.19.2", features = ["full"] }
+tracing-subscriber = { version = "^0.3.14", default-features = false, features = ["std", "ansi", "tracing-log"] }
 
 [profile.release]
 lto = true


### PR DESCRIPTION
* Bump clap to 3.2.12
* Bump serde to 1.0.139
* Bump serde_yaml to 0.8.26
* Bump tokio to 1.20.0

Signed-off-by: Florentin Dubois <florentin.dubois@clever-cloud.com>