### PR TITLE
feat(addon-provider): update Redis add-on version to 8.8.0

### DIFF
--- a/src/v4/addon_provider/redis.rs
+++ b/src/v4/addon_provider/redis.rs
@@ -27,7 +27,7 @@ use crate::{
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
-    #[error("failed to parse version from {0}, available versions are 8.6.1 and 7.2.4")]
+    #[error("failed to parse version from {0}, available versions are 8.8.0 and 7.2.4")]
     ParseVersion(String),
     #[error("failed to get information about addon provider '{0}', {1}")]
     Get(AddonProviderId, ClientError),
@@ -42,7 +42,7 @@ pub enum Error {
 #[repr(i32)]
 pub enum Version {
     V7dot2dot4 = 724,
-    V8dot6dot1 = 861,
+    V8dot8dot0 = 880,
 }
 
 impl FromStr for Version {
@@ -50,7 +50,7 @@ impl FromStr for Version {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Ok(match s {
-            "8.6.1" => Self::V8dot6dot1,
+            "8.8.0" => Self::V8dot8dot0,
             "7.2.4" => Self::V7dot2dot4,
             _ => {
                 return Err(Error::ParseVersion(s.to_owned()));
@@ -78,7 +78,7 @@ impl Display for Version {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
             Self::V7dot2dot4 => write!(f, "7.2.4"),
-            Self::V8dot6dot1 => write!(f, "8.6.1"),
+            Self::V8dot8dot0 => write!(f, "8.8.0"),
         }
     }
 }
@@ -122,7 +122,7 @@ mod tests {
     #[test]
     fn version_string_round_trip() {
         for (s, version) in [
-            ("8.6.1", Version::V8dot6dot1),
+            ("8.8.0", Version::V8dot8dot0),
             ("7.2.4", Version::V7dot2dot4),
         ] {
             assert_eq!(Version::from_str(s).unwrap(), version);


### PR DESCRIPTION
Update the Redis add-on version from `8.6.1` to `8.8.0`.